### PR TITLE
DP-1 ObserverPattern 프레임워크 정리

### DIFF
--- a/ObserverPattern/Observer.cpp
+++ b/ObserverPattern/Observer.cpp
@@ -7,12 +7,10 @@
 
 void CObserver::NativeConstruct()
 {
-	InitObserverMember();
 }
 
 void CObserver::NativeDestuct()
 {
-	DestroyObserverMember();
 }
 
 void CObserver::Tick()
@@ -20,45 +18,10 @@ void CObserver::Tick()
 	GetWorld()->Tick();
 }
 
-void CObserver::InitObserverMember()
+void CObserver::Subscirbe(CObject* InObejct, EObserverContent InObserverContent)
 {
-	// Set Observers size
-	Observers.reserve(static_cast<size_t>(EObserverContent::Max));
-
-	// Max has no content
-	for (int i = 0; i < static_cast<int>(EObserverContent::Max); ++i)
-	{
-		Observers.push_back(GetObserver(EObserverContent(i)));
-	}
-
-}
-
-void CObserver::DestroyObserverMember()
-{
-	for (CObserver* Observer : Observers)
-	{
-		delete Observer;
-	}
-
-	if (!Observers.empty())
-	{
-		std::cout << "CObserver::DestroyObserverMember - Observers empty fail.";
-		return;
-	}
-}
-
-CObserver* CObserver::GetObserver(EObserverContent InObserverContent)
-{
-	switch (InObserverContent)
-	{
-		case EObserverContent::World:
-			return reinterpret_cast<CObserver*>(CWorld::Get());
-		case EObserverContent::Max:
-			std::cout << "CObserver::GetObserver - you inputs EObserverContent::Max";
-			return nullptr;
-	}
-
-	return nullptr;
+	// Gunny Todo
+	// apply InObejct to Observer
 }
 
 CWorld* CObserver::GetWorld()

--- a/ObserverPattern/Observer.h
+++ b/ObserverPattern/Observer.h
@@ -7,7 +7,9 @@ enum class EObserverContent
 	Max,
 };
 
+// forward declare
 class CWorld;
+class CObject;
 
 class CObserver
 	: public CSingleton<typename CObserver>
@@ -23,16 +25,8 @@ public:
 	virtual	void Tick() override;
 
 	// Subscriber 
-	//virtual void Subscribe();
-	//virtual void Unsubscribe();
+	void Subscirbe(CObject* InObejct, EObserverContent InObserverContent);
 
 private:
-	void InitObserverMember();
-	void DestroyObserverMember();
-
-	CObserver* GetObserver(EObserverContent InObserverContent);
 	CWorld* GetWorld();
-
-
-	std::vector<CObserver*> Observers;
 };

--- a/ObserverPattern/ObserverPattern.vcxproj
+++ b/ObserverPattern/ObserverPattern.vcxproj
@@ -126,7 +126,6 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Object.cpp" />
     <ClCompile Include="Observer.cpp" />
-    <ClCompile Include="Singleton.cpp" />
     <ClCompile Include="World.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/ObserverPattern/ObserverPattern.vcxproj.filters
+++ b/ObserverPattern/ObserverPattern.vcxproj.filters
@@ -39,9 +39,6 @@
     <ClCompile Include="Object.cpp">
       <Filter>Source\0_Main\0_Object</Filter>
     </ClCompile>
-    <ClCompile Include="Singleton.cpp">
-      <Filter>Source\1_DesignPattern\Singleton</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Observer.h">

--- a/ObserverPattern/ProjectHeader.h
+++ b/ObserverPattern/ProjectHeader.h
@@ -7,3 +7,9 @@ CObserver* GetObserver()
 {
 	return CObserver::Get();
 }
+
+void Subscirbe(CObject* InObejct, EObserverContent InObserverContent)
+{
+	CObserver* Observer = CObserver::Get();
+	Observer->Subscirbe(InObejct, InObserverContent);
+}

--- a/ObserverPattern/Singleton.cpp
+++ b/ObserverPattern/Singleton.cpp
@@ -1,1 +1,0 @@
-#include "Singleton.h"

--- a/ObserverPattern/Singleton.h
+++ b/ObserverPattern/Singleton.h
@@ -27,9 +27,7 @@ public:
 		}
 		else
 		{
-			// Gunny Todo. JsonLog
-			// Can be added by NUGET?
-			std::cout << "Instance does not exist." << std::endl;
+			std::cout << "CSingleton - Destroy Instance does not exist." << std::endl;
 		}
 	}
 

--- a/ObserverPattern/World.cpp
+++ b/ObserverPattern/World.cpp
@@ -12,6 +12,6 @@ void CWorld::NativeDestuct()
 
 void CWorld::Tick()
 {
-	// gunny temp code
+	// Gunny temp code
 	std::cout << "CWorld::Tick has been called.\n";
 }

--- a/ObserverPattern/World.h
+++ b/ObserverPattern/World.h
@@ -8,13 +8,8 @@ public:
 	CWorld() {}
 	~CWorld() {}
 
-	// Construct and Destruct
 	virtual void NativeConstruct() override;
 	virtual void NativeDestuct() override;
 
 	void Tick() override;
-	// Subscriber 
-	//virtual void Subscribe() override;
-	//virtual void Unsubscribe() override;
-
 };

--- a/ObserverPattern/main.cpp
+++ b/ObserverPattern/main.cpp
@@ -1,26 +1,55 @@
 #include "ProjectHeader.h"
 
-void InitInstance();
-void DestroyInstance();
+// Project Init
+void Init();
+void Destroy();
+
+// Observer
+void InitObserver();
+void DestroyObserver();
+
+// Widget
+void InitWidgets();
+void DestroyWidgets();
 
 int main()
 {
-	InitInstance();
+	Init();
 
 	while (true)
 	{
 		GetObserver()->Tick();
 	}
 
-	DestroyInstance();
 }
 
-void InitInstance()
+void Init()
+{
+	InitObserver();
+	InitWidgets();
+}
+
+void Destroy()
+{
+	DestroyObserver();
+}
+
+void InitObserver()
 {
 	GetObserver()->NativeConstruct();
 }
 
-void DestroyInstance()
+void DestroyObserver()
 {
 	GetObserver()->NativeDestuct();
+}
+
+void InitWidgets()
+{
+
+}
+
+void DestroyWidgets()
+{
+
 }


### PR DESCRIPTION
- 쓸모없는 맴버함수 제거

- main에 init, destroyer 추가