### PR TITLE
modifing .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,11 +32,7 @@
 *.app
 
 # Debug, Release folder
-\.vs
-\x64
-\Debug
-\Release
-
-# VisualStudio
-*.vcxproj
-*.vcxproj.user
+*/.vs
+*/x64
+*/Debug
+*/Release


### PR DESCRIPTION
vcxproj 파일 없으면 솔루션파일이 안열린다. - 다시 추가했음. 
매번 솔루션파일을 열 때마다 수정되니 모두 같은 버전의 sdk를 사용하거나(이건 불가능 할 것 같으니...)  해당 파일은 commit 하지 않도록 해야함.