### PR TITLE
중개자 패턴 수정

### DIFF
--- a/ServiceMediatorPattern/ServiceMediatorPattern/ServiceMediatorPattern/Framework.cpp
+++ b/ServiceMediatorPattern/ServiceMediatorPattern/ServiceMediatorPattern/Framework.cpp
@@ -21,6 +21,8 @@ void Framework::initialize()
 #endif
 
 #ifdef NULL_MEDIATOR_SET
+	// 단 이렇게 이니셜라이즈를 해주면 위에 모바일오디오를 또 사용하게 된다.
+	//NullMediator::initialize();	// 본래의 의도가 어떤건지 궁금스
 	NullMediator::provide(audio);
 #else // 
 	Mediator::provide(audio);

--- a/ServiceMediatorPattern/ServiceMediatorPattern/ServiceMediatorPattern/Mediator.h
+++ b/ServiceMediatorPattern/ServiceMediatorPattern/ServiceMediatorPattern/Mediator.h
@@ -25,7 +25,7 @@ public:
 	static void initialize() {
 		service_ = &nullService;
 	}
-	static Audio& getAudio() { return *service_; }
+	static Audio* getAudio() { return service_; }
 	static void provide(Audio* service);
 
 private:

--- a/ServiceMediatorPattern/ServiceMediatorPattern/ServiceMediatorPattern/main.cpp
+++ b/ServiceMediatorPattern/ServiceMediatorPattern/ServiceMediatorPattern/main.cpp
@@ -15,5 +15,12 @@ int main()
 	//어떤 구체 클래스가 실제로 사용되는지는 서비스를 제공하는 초기화 
 	//코드에서만 알 수 있다.
 	Audio* audio = Mediator::getAudio();
+
+	// audio가 널인경우는, 위 Framework의 초기화 과정에서 NullMediator을 사용한다고 했을경우이므로, 
+	// NullMediator에서 getAudio가 되어야한다.
+	if (!audio)
+	{
+		audio = NullMediator::getAudio();
+	}
 	audio->playSound(VOLUME_LOUD);
 }


### PR DESCRIPTION
- 일단 main.cpp를 기점으로 수정해봤음.

- main에서 getAudio를 할 때, 실패하는 경우(null 가드) NullMediator에서 get하도록 가드 코드를 추가했다.

- 이렇게 되면 별 크래시 없이 프로그램이 잘 종료하게 된다.

- 한 가지 궁금한점! Framework::initialize에서 NullMediator::initialize 함수 호출이 빠져있는 듯 한데, 이니셜라이즈를 하게 되면, NullMediator::provide 함수 구현에 따라 위에 모바일오디오가 Set되게 된다.. 뒤이어 수정 바람